### PR TITLE
fix(launch_cluster): postgres password in quotes

### DIFF
--- a/environment_examples/render_global_env.py
+++ b/environment_examples/render_global_env.py
@@ -1,4 +1,5 @@
 from jinja2 import Environment, FileSystemLoader
+import shlex
 
 
 def create_spaced_list_of_strings(l):
@@ -46,6 +47,7 @@ var_dict["dns_hostnames"] = create_spaced_list_of_strings(
 var_dict["dns_zones"] = create_spaced_list_of_strings(
     ["$DNS_ZONE"] + var_dict["add_dns_zones"]
 )
+var_dict["postgres_password"] = shlex.quote(var_dict["postgres_password"])
 
 # Load and render template
 env = Environment(loader=FileSystemLoader("."))

--- a/environment_examples/render_local_env.py
+++ b/environment_examples/render_local_env.py
@@ -1,4 +1,5 @@
 from jinja2 import Environment, FileSystemLoader
+import shlex
 
 
 def create_double_quoted_list_of_strings(l):
@@ -60,6 +61,7 @@ var_dict["pcg_service_account_addon"] = " ".join(
         for sec in var_dict["add_storage_secrets"]
     ]
 )
+var_dict["postgres_password"] = shlex.quote(var_dict["postgres_password"])
 
 
 # Load and render template

--- a/infrastructure/global/launch_cluster.sh
+++ b/infrastructure/global/launch_cluster.sh
@@ -18,6 +18,6 @@ gcloud sql instances create $SQL_INSTANCE_NAME --database-version=POSTGRES_9_6 -
 gcloud sql databases create $SQL_AUTH_DB_NAME --instance=$SQL_INSTANCE_NAME
 gcloud sql databases create $SQL_INFO_DB_NAME --instance=$SQL_INSTANCE_NAME
 
-gcloud sql users set-password $POSTGRES_WRITE_USER --instance=$SQL_INSTANCE_NAME --password=$POSTGRES_WRITE_USER_PASSWORD
+gcloud sql users set-password $POSTGRES_WRITE_USER --instance=$SQL_INSTANCE_NAME --password="$POSTGRES_WRITE_USER_PASSWORD"
 
 mkdir -p $ADD_STORAGE_SECRET_FOLDER

--- a/infrastructure/local/launch_cluster.sh
+++ b/infrastructure/local/launch_cluster.sh
@@ -24,7 +24,7 @@ gcloud sql instances create $SQL_INSTANCE_NAME --database-version=POSTGRES_13 --
 gcloud sql databases create $SQL_ANNO_DB_NAME --instance=$SQL_INSTANCE_NAME
 gcloud sql databases create $SQL_MAT_DB_NAME --instance=$SQL_INSTANCE_NAME
 
-gcloud sql users set-password $POSTGRES_WRITE_USER --instance=$SQL_INSTANCE_NAME --password=$POSTGRES_WRITE_USER_PASSWORD
+gcloud sql users set-password $POSTGRES_WRITE_USER --instance=$SQL_INSTANCE_NAME --password="$POSTGRES_WRITE_USER_PASSWORD"
 
 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user "$(gcloud config get-value account)"
 kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/k8s-stackdriver/master/custom-metrics-stackdriver-adapter/deploy/production/adapter.yaml


### PR DESCRIPTION
Resolves #2 

`render_local_env.py`:
```python
"postgres_password": "This \\ is\" the' pass\n ${phrase}",
```


`local_env.sh`:
```bash
export POSTGRES_WRITE_USER_PASSWORD='This \ is" the'"'"' pass
 ${phrase}'
```


`echo --password="$POSTGRES_WRITE_USER_PASSWORD"`:
```bash
--password=This \ is" the' pass
 ${phrase}
```

Not sure about the newline... but at least for regular whitespaces and other less special special characters, this should work.