### PR TITLE
Expose version numbers as environment vars + update

### DIFF
--- a/environment_examples/global_env_template.sh
+++ b/environment_examples/global_env_template.sh
@@ -26,8 +26,10 @@ export DOCKER_REPOSITORY={{ docker_repository }}
 
 export NGINX_INGRESS_CONTROLLER_NAME=contrasting-umbrellabird
 export NGINX_INGRESS_SERVICE_NAME=nginx-ingress-service
+export NGINX_INGRESS_CHART_VERSION=3.4.1
+export CERT_MANAGER_CHART_VERSION=v1.0.2
 export DNS_HOSTNAME=${ENVIRONMENT}.${DOMAIN_NAME}
-export CRD_GITHUB_PATH=https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
+# export CRD_GITHUB_PATH=https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
 export DNS_HOSTNAMES=({{ dns_hostnames }})
 export DNS_ZONES=({{ dns_zones }})
 
@@ -50,9 +52,22 @@ do
 done
 export DNS_INGRESS_PARA
 
+export GCE_PROXY_IMAGE=gcr.io/cloudsql-docker/gce-proxy
+export GCE_PROXY_TAG=1.11
+
+export SYSCTL_BUDDY_IMAGE=alpine
+export SYSCTL_BUDDY_TAG=3.4
+
+export FLUENTD_GCP_IMAGE=gcr.io/google-containers/fluentd-gcp
+export FLUENTD_GCP_TAG=2.0.17
+
+export PROMETHEUS_TO_SD_IMAGE=gcr.io/google-containers/prometheus-to-sd
+export PROMETHEUS_TO_SD_TAG=v0.2.6
+
 
 # SQL INSTANCE
 
+export SQL_INSTANCE_VERSION=POSTGRES_9_6
 export SQL_INSTANCE_CPU=1
 export SQL_INSTANCE_MEMORY=4
 export SQL_AUTH_DB_NAME=authentication

--- a/environment_examples/global_env_template.sh
+++ b/environment_examples/global_env_template.sh
@@ -26,8 +26,8 @@ export DOCKER_REPOSITORY={{ docker_repository }}
 
 export NGINX_INGRESS_CONTROLLER_NAME=contrasting-umbrellabird
 export NGINX_INGRESS_SERVICE_NAME=nginx-ingress-service
-export NGINX_INGRESS_CHART_VERSION=3.4.1
-export CERT_MANAGER_CHART_VERSION=v1.0.2
+export NGINX_INGRESS_CHART_VERSION=4.1.4
+export CERT_MANAGER_CHART_VERSION=v1.8.0
 export DNS_HOSTNAME=${ENVIRONMENT}.${DOMAIN_NAME}
 # export CRD_GITHUB_PATH=https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
 export DNS_HOSTNAMES=({{ dns_hostnames }})
@@ -53,21 +53,21 @@ done
 export DNS_INGRESS_PARA
 
 export GCE_PROXY_IMAGE=gcr.io/cloudsql-docker/gce-proxy
-export GCE_PROXY_TAG=1.11
+export GCE_PROXY_TAG=1.31.0
 
 export SYSCTL_BUDDY_IMAGE=alpine
-export SYSCTL_BUDDY_TAG=3.4
+export SYSCTL_BUDDY_TAG=3.16
 
 export FLUENTD_GCP_IMAGE=gcr.io/google-containers/fluentd-gcp
-export FLUENTD_GCP_TAG=2.0.17
+export FLUENTD_GCP_TAG=2.1.1
 
 export PROMETHEUS_TO_SD_IMAGE=gcr.io/google-containers/prometheus-to-sd
-export PROMETHEUS_TO_SD_TAG=v0.2.6
+export PROMETHEUS_TO_SD_TAG=v0.9.2
 
 
 # SQL INSTANCE
 
-export SQL_INSTANCE_VERSION=POSTGRES_9_6
+export SQL_INSTANCE_VERSION=POSTGRES_14
 export SQL_INSTANCE_CPU=1
 export SQL_INSTANCE_MEMORY=4
 export SQL_AUTH_DB_NAME=authentication

--- a/environment_examples/local_env_template.sh
+++ b/environment_examples/local_env_template.sh
@@ -30,8 +30,10 @@ export DOCKER_REPOSITORY={{ docker_repository }}
 
 export NGINX_INGRESS_CONTROLLER_NAME=contrasting-umbrellabird
 export NGINX_INGRESS_SERVICE_NAME=nginx-ingress-service
+export NGINX_INGRESS_CHART_VERSION=3.4.1
+export CERT_MANAGER_CHART_VERSION=v1.0.2
 export DNS_HOSTNAME=${ENVIRONMENT}.${DOMAIN_NAME}
-export CRD_GITHUB_PATH=https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
+# export CRD_GITHUB_PATH=https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
 export DNS_HOSTNAMES=({{ dns_hostnames }})
 export DNS_ZONES=({{ dns_zones }})
 
@@ -54,9 +56,32 @@ do
 done
 export DNS_INGRESS_PARA
 
+export GCE_PROXY_IMAGE=gcr.io/cloudsql-docker/gce-proxy
+export GCE_PROXY_TAG=1.11
+
+export SYSCTL_BUDDY_IMAGE=alpine
+export SYSCTL_BUDDY_TAG=3.4
+
+export FLUENTD_GCP_IMAGE=gcr.io/google-containers/fluentd-gcp
+export FLUENTD_GCP_TAG=2.0.17
+
+export PROMETHEUS_TO_SD_IMAGE=gcr.io/google-containers/prometheus-to-sd
+export PROMETHEUS_TO_SD_TAG=v0.8.0
+
+export CELERY_EXPORTER_IMAGE=gcr.io/${DATA_PROJECT_NAME}/celery-metric-exporter
+export CELERY_EXPORTER_TAG=v5
+
+export FLOWER_IMAGE=mher/flower
+export FLOWER_TAG=0.9.5
+
+
+# REDIS
+
+export REDIS_CHART_VERSION=10.7.11
 
 # SQL INSTANCE
 
+export SQL_INSTANCE_VERSION=POSTGRES_13
 export SQL_INSTANCE_CPU=4
 export SQL_INSTANCE_MEMORY=16
 export SQL_ANNO_DB_NAME=annotation

--- a/environment_examples/local_env_template.sh
+++ b/environment_examples/local_env_template.sh
@@ -30,8 +30,8 @@ export DOCKER_REPOSITORY={{ docker_repository }}
 
 export NGINX_INGRESS_CONTROLLER_NAME=contrasting-umbrellabird
 export NGINX_INGRESS_SERVICE_NAME=nginx-ingress-service
-export NGINX_INGRESS_CHART_VERSION=3.4.1
-export CERT_MANAGER_CHART_VERSION=v1.0.2
+export NGINX_INGRESS_CHART_VERSION=4.1.4
+export CERT_MANAGER_CHART_VERSION=v1.8.0
 export DNS_HOSTNAME=${ENVIRONMENT}.${DOMAIN_NAME}
 # export CRD_GITHUB_PATH=https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
 export DNS_HOSTNAMES=({{ dns_hostnames }})
@@ -57,31 +57,31 @@ done
 export DNS_INGRESS_PARA
 
 export GCE_PROXY_IMAGE=gcr.io/cloudsql-docker/gce-proxy
-export GCE_PROXY_TAG=1.11
+export GCE_PROXY_TAG=1.31.0
 
 export SYSCTL_BUDDY_IMAGE=alpine
-export SYSCTL_BUDDY_TAG=3.4
+export SYSCTL_BUDDY_TAG=3.16
 
 export FLUENTD_GCP_IMAGE=gcr.io/google-containers/fluentd-gcp
-export FLUENTD_GCP_TAG=2.0.17
+export FLUENTD_GCP_TAG=2.1.1
 
 export PROMETHEUS_TO_SD_IMAGE=gcr.io/google-containers/prometheus-to-sd
-export PROMETHEUS_TO_SD_TAG=v0.8.0
+export PROMETHEUS_TO_SD_TAG=v0.9.2
 
 export CELERY_EXPORTER_IMAGE=gcr.io/${DATA_PROJECT_NAME}/celery-metric-exporter
 export CELERY_EXPORTER_TAG=v5
 
-export FLOWER_IMAGE=mher/flower
-export FLOWER_TAG=0.9.5
+export FLOWER_IMAGE=cfarrend/flower
+export FLOWER_TAG=v1.0.0
 
 
 # REDIS
 
-export REDIS_CHART_VERSION=10.7.11
+export REDIS_CHART_VERSION=16.12.2
 
 # SQL INSTANCE
 
-export SQL_INSTANCE_VERSION=POSTGRES_13
+export SQL_INSTANCE_VERSION=POSTGRES_14
 export SQL_INSTANCE_CPU=4
 export SQL_INSTANCE_MEMORY=16
 export SQL_ANNO_DB_NAME=annotation

--- a/infrastructure/global/configure_ingress.sh
+++ b/infrastructure/global/configure_ingress.sh
@@ -1,4 +1,4 @@
 source env_config.sh
 source $ENV_REPO_PATH/$1.sh
 
-helm upgrade -f $YAML_FOLDER/nginx-ingress-helm-config.yml ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --version 3.4.1 --namespace kube-system
+helm upgrade -f $YAML_FOLDER/nginx-ingress-helm-config.yml ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --version ${NGINX_INGRESS_CHART_VERSION} --namespace kube-system

--- a/infrastructure/global/launch_cluster.sh
+++ b/infrastructure/global/launch_cluster.sh
@@ -13,7 +13,7 @@ gcloud compute addresses create $CLUSTER_NAME --region=$REGION
 
 gcloud redis instances create $REDIS_NAME --size=2 --region=$REGION --zone=$ZONE --network=$NETWORK_NAME
  
-gcloud sql instances create $SQL_INSTANCE_NAME --database-version=POSTGRES_9_6 --region=$REGION --cpu=$SQL_INSTANCE_CPU --memory=$SQL_INSTANCE_MEMORY
+gcloud sql instances create $SQL_INSTANCE_NAME --database-version=$SQL_INSTANCE_VERSION --region=$REGION --cpu=$SQL_INSTANCE_CPU --memory=$SQL_INSTANCE_MEMORY
 
 gcloud sql databases create $SQL_AUTH_DB_NAME --instance=$SQL_INSTANCE_NAME
 gcloud sql databases create $SQL_INFO_DB_NAME --instance=$SQL_INSTANCE_NAME

--- a/infrastructure/global/run_cloudsql_proxy.sh
+++ b/infrastructure/global/run_cloudsql_proxy.sh
@@ -3,13 +3,13 @@ source $ENV_REPO_PATH/$1.sh
 gcloud auth application-default login
 export INSTANCE_CONNECTION_NAME=$PROJECT_NAME:$REGION:$SQL_INSTANCE_NAME
 
-docker pull gcr.io/cloudsql-docker/gce-proxy:1.16
+docker pull $GCE_PROXY_IMAGE:$GCE_PROXY_TAG
 docker rm --force gce-proxy
 docker rm --force adminer
 docker run -d \
 -v $HOME/.config/gcloud/:/config \
   -p 127.0.0.1:3306:3306 \
   --name gce-proxy \
-  gcr.io/cloudsql-docker/gce-proxy:1.16 /cloud_sql_proxy \
+  $GCE_PROXY_IMAGE:$GCE_PROXY_TAG /cloud_sql_proxy \
   -instances=$INSTANCE_CONNECTION_NAME=tcp:0.0.0.0:3306 -credential_file=/config/application_default_credentials.json
 docker run --link gce-proxy:db -p 8080:8080 --name adminer adminer

--- a/infrastructure/global/setup_ingress.sh
+++ b/infrastructure/global/setup_ingress.sh
@@ -7,7 +7,7 @@ kubectl apply -f $YAML_FOLDER/service-accounts.yml
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo add stable https://charts.helm.sh/stable
 helm repo update
-helm install ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --set rbac.create=true --namespace kube-system --version 3.4.1
+helm install ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --set rbac.create=true --namespace kube-system --version $NGINX_INGRESS_CHART_VERSION
 
 gcloud compute addresses describe ${CLUSTER_NAME} --region $REGION | grep address: | sed "s/address: //"
 
@@ -20,7 +20,7 @@ kubectl create namespace cert-manager
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.0.2 \
+  --version $CERT_MANAGER_CHART_VERSION \
   -f $YAML_FOLDER/cert-manager-values.yml \
   --set installCRDs=true
 ./infrastructure/global/configure_ingress.sh $1

--- a/infrastructure/local/configure_ingress.sh
+++ b/infrastructure/local/configure_ingress.sh
@@ -1,4 +1,4 @@
 source env_config.sh
 source $ENV_REPO_PATH/$1.sh
 
-helm upgrade -f $YAML_FOLDER/nginx-ingress-helm-config.yml ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --version 4.1.2 --namespace kube-system
+helm upgrade -f $YAML_FOLDER/nginx-ingress-helm-config.yml ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --version ${NGINX_INGRESS_CHART_VERSION} --namespace kube-system

--- a/infrastructure/local/install_redis.sh
+++ b/infrastructure/local/install_redis.sh
@@ -4,9 +4,9 @@ source $ENV_REPO_PATH/$1.sh
 ./infrastructure/local/switch_context.sh $1
 
 helm repo add bitnami https://charts.bitnami.com/bitnami
-helm install redis-release  bitnami/redis --values ${YAML_FOLDER}/redis_production_values.yml --version 10.7.11
+helm install redis-release  bitnami/redis --values ${YAML_FOLDER}/redis_production_values.yml --version ${REDIS_CHART_VERSION}
 
-# helm upgrade --force --recreate-pods -f ${YAML_FOLDER}/redis_production_values.yml redis-release bitnami/redis  --version 10.7.11
+# helm upgrade --force --recreate-pods -f ${YAML_FOLDER}/redis_production_values.yml redis-release bitnami/redis  --version ${REDIS_CHART_VERSION}
 
 helm repo add zettaai http://zetta.ai/helm-charts/charts
 helm repo update

--- a/infrastructure/local/launch_cluster.sh
+++ b/infrastructure/local/launch_cluster.sh
@@ -19,7 +19,7 @@ gcloud container node-pools delete default-pool --cluster $CLUSTER_NAME
 
 gcloud compute addresses create $CLUSTER_NAME --region=$REGION
 
-gcloud sql instances create $SQL_INSTANCE_NAME --database-version=POSTGRES_13 --region=$REGION --cpu=$SQL_INSTANCE_CPU --memory=$SQL_INSTANCE_MEMORY
+gcloud sql instances create $SQL_INSTANCE_NAME --database-version=$SQL_INSTANCE_VERSION --region=$REGION --cpu=$SQL_INSTANCE_CPU --memory=$SQL_INSTANCE_MEMORY
 
 gcloud sql databases create $SQL_ANNO_DB_NAME --instance=$SQL_INSTANCE_NAME
 gcloud sql databases create $SQL_MAT_DB_NAME --instance=$SQL_INSTANCE_NAME

--- a/infrastructure/local/run_cloudsql_proxy.sh
+++ b/infrastructure/local/run_cloudsql_proxy.sh
@@ -3,13 +3,13 @@ source $ENV_REPO_PATH/$1.sh
 gcloud auth application-default login
 export INSTANCE_CONNECTION_NAME=$PROJECT_NAME:$REGION:$SQL_INSTANCE_NAME
 
-docker pull gcr.io/cloudsql-docker/gce-proxy:1.16
+docker pull $GCE_PROXY_IMAGE:$GCE_PROXY_TAG
 docker rm --force gce-proxy
 docker rm --force adminer
 docker run -d \
 -v $HOME/.config/gcloud/:/config \
   -p 127.0.0.1:3306:3306 \
   --name gce-proxy \
-  gcr.io/cloudsql-docker/gce-proxy:1.16 /cloud_sql_proxy \
+  $GCE_PROXY_IMAGE:$GCE_PROXY_TAG /cloud_sql_proxy \
   -instances=$INSTANCE_CONNECTION_NAME=tcp:0.0.0.0:3306 -credential_file=/config/application_default_credentials.json
 docker run --link gce-proxy:db -p 8080:8080 --name adminer adminer

--- a/infrastructure/local/setup_ingress.sh
+++ b/infrastructure/local/setup_ingress.sh
@@ -8,7 +8,7 @@ kubectl apply -f $YAML_FOLDER/service-accounts.yml
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo add stable https://charts.helm.sh/stable
 helm repo update
-helm install ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --set rbac.create=true --namespace kube-system --version 3.4.1 -f $YAML_FOLDER/nginx-ingress-helm-config.yml
+helm install ${NGINX_INGRESS_CONTROLLER_NAME} ingress-nginx/ingress-nginx --set rbac.create=true --namespace kube-system --version $NGINX_INGRESS_CHART_VERSION -f $YAML_FOLDER/nginx-ingress-helm-config.yml
 
 gcloud compute addresses describe ${CLUSTER_NAME} --region $REGION | grep address: | sed "s/address: //"
 
@@ -21,7 +21,7 @@ kubectl create namespace cert-manager
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.0.2 \
+  --version $CERT_MANAGER_CHART_VERSION \
   -f $YAML_FOLDER/cert-manager-values.yml \
   --set installCRDs=true
 ./infrastructure/local/configure_ingress.sh $1

--- a/infrastructure/local/update_redis.sh
+++ b/infrastructure/local/update_redis.sh
@@ -4,4 +4,4 @@ source $ENV_REPO_PATH/$1.sh
 ./infrastructure/local/switch_context.sh $1
 ./infrastructure/local/create_yaml_files_from_templates.sh $1
 
-helm upgrade --recreate-pods -f ${YAML_FOLDER}/redis_production_values.yml redis-release bitnami/redis  --version 10.7.11
+helm upgrade --recreate-pods -f ${YAML_FOLDER}/redis_production_values.yml redis-release bitnami/redis  --version ${REDIS_CHART_VERSION}

--- a/kubetemplates/annotation.yml
+++ b/kubetemplates/annotation.yml
@@ -132,7 +132,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -151,7 +151,7 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/auth.yml
+++ b/kubetemplates/auth.yml
@@ -136,7 +136,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -155,7 +155,7 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/celery-scaler.yml
+++ b/kubetemplates/celery-scaler.yml
@@ -4,7 +4,7 @@ metadata:
   name: celery-scaler
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: celery
   minReplicas: 1

--- a/kubetemplates/dash.yml
+++ b/kubetemplates/dash.yml
@@ -114,7 +114,7 @@ spec:
           timeoutSeconds: 1
           periodSeconds: 60
       - name: sysctl-buddy
-        image: alpine:3.4
+        image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
         command:
         - /bin/sh
         - -c

--- a/kubetemplates/fluentd-custom-daemonset.yml
+++ b/kubetemplates/fluentd-custom-daemonset.yml
@@ -36,7 +36,7 @@ spec:
       - env:
         - name: FLUENTD_ARGS
           value: --no-supervisor
-        image: gcr.io/google-containers/fluentd-gcp:2.0.17
+        image: ${FLUENTD_GCP_IMAGE}:${FLUENTD_GCP_TAG}
         imagePullPolicy: IfNotPresent
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
@@ -104,7 +104,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.6
+        image: ${PROMETHEUS_TO_SD_IMAGE}:${PROMETHEUS_TO_SD_TAG}
         imagePullPolicy: IfNotPresent
         name: prometheus-to-sd-exporter
         resources: {}

--- a/kubetemplates/guidebook.yml
+++ b/kubetemplates/guidebook.yml
@@ -127,7 +127,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/info.yml
+++ b/kubetemplates/info.yml
@@ -72,7 +72,7 @@ spec:
             secretName: ${INFOSERVICE_SERVICE_ACCOUNT_SECRET}
       containers:
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -132,7 +132,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/materialize.yml
+++ b/kubetemplates/materialize.yml
@@ -156,7 +156,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -175,7 +175,7 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/materialize_worker.yml
+++ b/kubetemplates/materialize_worker.yml
@@ -67,7 +67,7 @@ spec:
           emptyDir: {}
       containers:
         - name: celery-exporter
-          image: gcr.io/${DATA_PROJECT_NAME}/celery-metric-exporter:v5
+          image: ${CELERY_EXPORTER_IMAGE}:${CELERY_EXPORTER_TAG}
           command: ["python"]
           args:
             - cli.py
@@ -242,7 +242,7 @@ spec:
           emptyDir: {}
       containers:
         - name: celery-exporter
-          image: gcr.io/${DATA_PROJECT_NAME}/celery-metric-exporter:v5
+          image: ${CELERY_EXPORTER_IMAGE}:${CELERY_EXPORTER_TAG}
           command: ["python"]
           args:
             - cli.py

--- a/kubetemplates/materialize_worker.yml
+++ b/kubetemplates/materialize_worker.yml
@@ -92,7 +92,7 @@ spec:
             - name: graceful-shut-down
               mountPath: /home/nginx/tmp/shutdown
         - name: prometheus-to-sd
-          image: gcr.io/google-containers/prometheus-to-sd:v0.8.0
+          image: ${PROMETHEUS_TO_SD_IMAGE}:${PROMETHEUS_TO_SD_TAG}
           command: ["/monitor"]
           args:
             - --source=http://localhost:9540/metrics
@@ -176,7 +176,7 @@ spec:
               exec:
                 command: ["/home/nginx/gracefully_shutdown_celery.sh"]
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -267,7 +267,7 @@ spec:
             - name: graceful-shut-down
               mountPath: /home/nginx/tmp/shutdown
         - name: prometheus-to-sd
-          image: gcr.io/google-containers/prometheus-to-sd:v0.8.0
+          image: ${PROMETHEUS_TO_SD_IMAGE}:${PROMETHEUS_TO_SD_TAG}
           command: ["/monitor"]
           args:
             - --source=http://localhost:9540/metrics
@@ -351,7 +351,7 @@ spec:
               exec:
                 command: ["/home/nginx/gracefully_shutdown_celery.sh"]
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -450,7 +450,7 @@ spec:
               cpu: 10m
               memory: 150Mi
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -497,7 +497,7 @@ spec:
     spec:
       containers:
         - name: flower
-          image: mher/flower:0.9.5
+          image: ${FLOWER_IMAGE}:${FLOWER_TAG}
           args:
             - flower
             - --broker=redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/0

--- a/kubetemplates/materialize_worker.yml
+++ b/kubetemplates/materialize_worker.yml
@@ -4,7 +4,7 @@ metadata:
   name: celery-producer-scaler
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: celery-producer
   minReplicas: ${CELERY_PRODUCER_MIN_REPLICAS}
@@ -21,7 +21,7 @@ metadata:
   name: celery-consumer-scaler
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: celery-consumer
   minReplicas: ${CELERY_CONSUMER_MIN_REPLICAS}

--- a/kubetemplates/meshing.yml
+++ b/kubetemplates/meshing.yml
@@ -134,7 +134,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/nglstate.yml
+++ b/kubetemplates/nglstate.yml
@@ -77,7 +77,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/pcgl2cache.yml
+++ b/kubetemplates/pcgl2cache.yml
@@ -131,7 +131,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/pmanagement.yml
+++ b/kubetemplates/pmanagement.yml
@@ -105,7 +105,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/pprogress.yml
+++ b/kubetemplates/pprogress.yml
@@ -115,7 +115,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/proxy.yml
+++ b/kubetemplates/proxy.yml
@@ -93,7 +93,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/pychunkedgraph.yml
+++ b/kubetemplates/pychunkedgraph.yml
@@ -153,7 +153,7 @@ spec:
         #          timeoutSeconds: 1
         #          periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/schema.yml
+++ b/kubetemplates/schema.yml
@@ -61,7 +61,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c

--- a/kubetemplates/sticky_auth.yml
+++ b/kubetemplates/sticky_auth.yml
@@ -142,7 +142,7 @@ spec:
             timeoutSeconds: 1
             periodSeconds: 60
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: ${GCE_PROXY_IMAGE}:${GCE_PROXY_TAG}
           command:
             [
               "/cloud_sql_proxy",
@@ -161,7 +161,7 @@ spec:
               mountPath: /secrets/cloudsql
               readOnly: true
         - name: sysctl-buddy
-          image: alpine:3.4
+          image: ${SYSCTL_BUDDY_IMAGE}:${SYSCTL_BUDDY_TAG}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
Two parts:

1) Add the image/chart/version descriptors to the local and global env templates. That should be _mostly_ safe, although there are a few occassions where currently different versions of the same service are used within the local deployment (e.g. prometheus-to-sd)

2) Update to recent versions. That's the risky part. I can report back after next deployment run with all the new stuff

Resolves #4 
Resolves #26 
Resolves #29
Resolves #31 