### PR TITLE
(fix) create SQL in data_project

### DIFF
--- a/kubetemplates/annotation.yml
+++ b/kubetemplates/annotation.yml
@@ -137,7 +137,7 @@ spec:
           command:
             [
               "/cloud_sql_proxy",
-              "-instances=${PROJECT_NAME}:${REGION}:${SQL_INSTANCE_NAME}=tcp:3306",
+              "-instances=${DATA_PROJECT_NAME}:${DATA_REGION}:${SQL_INSTANCE_NAME}=tcp:3306",
               "-credential_file=/secrets/cloudsql/${GOOGLE_SECRET_FILENAME}",
             ]
           resources:


### PR DESCRIPTION
I am using `DATA_PROJECT_NAME` instead of `SQL_PROJECT_NAME` since the latter is specific to my deployment repo and not included here. I also made sure the region matches `DATA_REGION`.