### PR TITLE
add project ID to redis cache creation

### DIFF
--- a/infrastructure/local/deploy_pcg_redis.sh
+++ b/infrastructure/local/deploy_pcg_redis.sh
@@ -1,4 +1,4 @@
 source env_config.sh
 source $ENV_REPO_PATH/$1.sh
 
-gcloud redis instances create $PCG_REDIS_NAME --size=1 --region=$REGION --zone=$ZONE --network=$NETWORK_NAME --redis-config maxmemory-policy=allkeys-lru
+gcloud redis instances create $PCG_REDIS_NAME --size=1 --project=$PROJECT_NAME --region=$REGION --zone=$ZONE --network=$NETWORK_NAME --redis-config maxmemory-policy=allkeys-lru


### PR DESCRIPTION
Adding the project ID to the PCG redis cache to ensure its created in the correct GCP project.  