### PR TITLE
Add MAT_SERVICE_MEM to set memory for materialization.

### DIFF
--- a/infrastructure/local/defaults.sh
+++ b/infrastructure/local/defaults.sh
@@ -3,6 +3,7 @@
 # Materialization engine configuration
 export MAT_QUERY_LIMIT_SIZE=500000
 export MAT_LOG_LEVEL=WARNING
+export MAT_SERVICE_MEM=850Mi
 
 # Derive MATERIALIZATION_UPLOAD_BUCKET_NAME / MATERIALIZATION_UPLOAD_BUCKET_PATH
 # from each other if only one is set.

--- a/kubetemplates/materialize.yml
+++ b/kubetemplates/materialize.yml
@@ -172,7 +172,7 @@ spec:
               value: "100000000" 
           resources:
             requests:
-              memory: 850Mi
+              memory: $MAT_SERVICE_MEM
               cpu: 200m
           readinessProbe:
             httpGet:


### PR DESCRIPTION
Bandaid for FANC deployment with large tables.